### PR TITLE
Remove unnecessary cunn and cutorch dependencies

### DIFF
--- a/sample.lua
+++ b/sample.lua
@@ -1,7 +1,5 @@
 require 'torch'
-require 'cutorch'
 require 'nn'
-require 'cunn'
 
 require 'LanguageModel'
 


### PR DESCRIPTION
fixes `sample.lua` so that it can be run in CPU mode without requiring `cunn` and `cutorch`