### PR TITLE
Fix `torch-hdf5` clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ luarocks install optim
 luarocks install lua-cjson
 
 # We need to install torch-hdf5 from GitHub
-git clone git@github.com:deepmind/torch-hdf5.git
+git clone https://github.com/deepmind/torch-hdf5
 cd torch-hdf5
 luarocks make hdf5-0-0.rockspec
 ```


### PR DESCRIPTION
Switch to https URL, so you can clone it without having to authenticate with github first