### PR TITLE
Update preprocess.py to support Python 3

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -36,18 +36,18 @@ if __name__ == '__main__':
   train_size = total_size - val_size - test_size
  
   if not args.quiet:
-    print 'Total vocabulary size: %d' % len(token_to_idx)
-    print 'Total tokens in file: %d' % total_size
-    print '  Training size: %d' % train_size
-    print '  Val size: %d' % val_size
-    print '  Test size: %d' % test_size
+    print('Total vocabulary size: %d' % len(token_to_idx))
+    print('Total tokens in file: %d' % total_size)
+    print('  Training size: %d' % train_size)
+    print('  Val size: %d' % val_size)
+    print('  Test size: %d' % test_size)
 
   # Choose the datatype based on the vocabulary size
   dtype = np.uint8
   if len(token_to_idx) > 255:
     dtype = np.uint32
   if not args.quiet:
-    print 'Using dtype ', dtype
+    print('Using dtype ', dtype)
 
   # Just load data into memory ... we'll have to do something more clever
   # for huge datasets but this should be fine for now
@@ -87,7 +87,7 @@ if __name__ == '__main__':
   # Dump a JSON file for the vocab
   json_data = {
     'token_to_idx': token_to_idx,
-    'idx_to_token': {v: k for k, v in token_to_idx.iteritems()},
+    'idx_to_token': {v: k for k, v in token_to_idx.items()},
   }
   with open(args.output_json, 'w') as f:
     json.dump(json_data, f)


### PR DESCRIPTION
Print statements to print function calls.
Use `items` instead of `iteritems`.

Tested on Python 2.7 and Python 3.5

---

Running preprocess.py under Python 3.3+ fixes #29 

For the following text file:

```
Test 😀!
```

Here's the (incorrect) Python 2.7 json output:

``` json
{"idx_to_token": {"1": "T", "2": "e", "3": "s", "4": "t", "5": " ", "6": "\ud83d", "7": "\ude00", "8": "!", "9": "\n"}, "token_to_idx": {"!": 8, " ": 5, "e": 2, "\ude00": 7, "\n": 9, "s": 3, "T": 1, "\ud83d": 6, "t": 4}}
```

And the correct Python3.3 json:

``` json
{"idx_to_token": {"1": "T", "2": "e", "3": "s", "4": "t", "5": " ", "6": "\ud83d\ude00", "7": "!", "8": "\n"}, "token_to_idx": {"t": 4, "s": 3, " ": 5, "\ud83d\ude00": 6, "!": 7, "e": 2, "\n": 8, "T": 1}}
```
