### PR TITLE
Improved bookkeeping of settings when resuming from existing checkpoint.

### DIFF
--- a/doc/flags.md
+++ b/doc/flags.md
@@ -20,6 +20,8 @@ The training script `train.lua` accepts the following command-line flags:
 
 **Model options**:
 - `-init_from`: Path to a checkpoint file from a previous run of `train.lua`. Use this to continue training from an existing checkpoint; if this flag is passed then the other flags in this section will be ignored and the architecture from the existing checkpoint will be used instead.
+- `-reset_training_history`: If resuming training from an existing checkpoint, set to 0 to keep the training history of that checkpoint, such as the validation loss numbers and benchmark information. Set to 1 to forget all previous training history (other than the model itself). Default is 1.
+- `-reset_training_position`: If resuming training from an existing checkpoint, set to 0 to resume training from the point in the training set where the existing checkpoint was saved. This is accomplished by skipping batches that have already been trained on. Set to 1 to start training from the beginning of the training set. Default is 1.
 - `-model_type`: The type of recurrent network to use; either `lstm` (default) or `rnn`. `lstm` is slower but better.
 - `-wordvec_size`: Dimension of learned word vector embeddings; default is 64. You probably won't need to change this.
 - `-rnn_size`: The number of hidden units in the RNN; default is 128. Larger values (256 or 512) are commonly used to learn more powerful models and for bigger datasets, but this will significantly slow down computation.

--- a/train.lua
+++ b/train.lua
@@ -96,7 +96,7 @@ if opt.init_from ~= '' then
   print('Initializing from ', opt.init_from)
   local checkpoint = torch.load(opt.init_from)
   model = checkpoint.model:type(dtype)
-  last_resumed_batch = checkpoint.val_loss_history_it[#checkpoint.val_loss_history_it]
+  last_resumed_batch = checkpoint.i
   -- Recover model-related parameters from the loaded checkpoint
   opt.model_type = checkpoint.opt.model_type
   opt.wordvec_dim = checkpoint.opt.wordvec_dim


### PR DESCRIPTION
Also added two new flags to control behavior when resuming. -reset_training_history controls whether the training statistics, such as validation loss numbers, are retained from the old checkpoint. -reset_training_position controls whether training should resume from the same place in the training data that it left off in the resumed checkpoint. Finally, flags which control only the model architecture are read from the resumed checkpoint instead of the command line to avoid confusion.

By default, both flags are set to 1, which should provide exactly the same behavior as before.

I needed this functionality for a project where I was attempting to train larger models; training was repeatedly interrupted due to memory errors coming from CUDA. My workaround was to checkpoint frequently and restart training automatically in case of failure, but that doesn't work very well if you have to go back to the beginning of a 1GB+ set of training data each time you restart.