### PR TITLE
support UTF-8 start_text

### DIFF
--- a/LanguageModel.lua
+++ b/LanguageModel.lua
@@ -5,6 +5,7 @@ require 'VanillaRNN'
 require 'LSTM'
 
 local utils = require 'util.utils'
+local utf8 = require 'lua-utf8'
 
 
 local LM, parent = torch.class('nn.LanguageModel', 'nn.Module')
@@ -122,9 +123,9 @@ end
 
 
 function LM:encode_string(s)
-  local encoded = torch.LongTensor(#s)
-  for i = 1, #s do
-    local token = s:sub(i, i)
+  local encoded = torch.LongTensor(utf8.len(s))
+  for i = 1, utf8.len(s) do
+    local token = utf8.sub(s, i, i)
     local idx = self.token_to_idx[token]
     assert(idx ~= nil, 'Got invalid idx')
     encoded[i] = idx

--- a/sample.lua
+++ b/sample.lua
@@ -15,7 +15,6 @@ cmd:option('-gpu_backend', 'cuda')
 cmd:option('-verbose', 0)
 local opt = cmd:parse(arg)
 
-
 local checkpoint = torch.load(opt.checkpoint)
 local model = checkpoint.model
 

--- a/torch-rnn-scm-1.rockspec
+++ b/torch-rnn-scm-1.rockspec
@@ -14,6 +14,7 @@ description = {
 dependencies = {
    "torch >= 7.0",
    "nn >= 1.0",
+   "luautf8 >= 1.2",
 }
 build = {
   type = "builtin",


### PR DESCRIPTION
I was trying to run stuff like:
```
th sample.lua -checkpoint $(ls -t cv/check*.t7 | head -1) -length 200 -temperature 0.75 -start_text "El país necesita"
```

And kept getting a `Got invalid idx` error. After digging a while I found that [lua doesn't work correctly with utf-8 strings](http://wowprogramming.com/snippets/UTF-8_aware_stringsub_7) :angry:, so I had to add a package to solve this. 

Please review. This PR might be controversial, as it adds a dependency, but I think that given that the main use-case for this lib is character-based learning, it should properly handle UTF-8 inputs both in the input files (https://github.com/jcjohnson/torch-rnn/pull/7) and CLI arguments (this PR).