### PR TITLE
Fix crash when loading old checkpoints with `-reset_iterations 0` flag

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -90,7 +90,14 @@ if opt.init_from ~= '' then
   local checkpoint = torch.load(opt.init_from)
   model = checkpoint.model:type(dtype)
   if opt.reset_iterations == 0 then
-    start_i = checkpoint.i
+    -- Backward compatibility with checkpoints made before
+    -- reset_iterations was implemented:
+    if checkpoint.i == nil then
+      print(string.format('reset_iterations: %s contains no iteration counter',
+                          opt.init_from))
+    else
+      start_i = checkpoint.i
+    end
   end
 else
   model = nn.LanguageModel(opt_clone):type(dtype)


### PR DESCRIPTION
Using `-reset_iterations 0` when initialising training from a checkpoint made before commit 6990602e9a46b1ffff690e6f8df4893bbf83d4fb causes an error, as reported in issue #82. This patch adds a backwards compatibility fix.

For checkpoint files which do not contain the iteration counter, a warning is printed on checkpoint load and training continues as if not flag was given:

    $ th train.lua $OPTIONS -init_from cv/checkpoint_10.t7 -reset_iterations 0
    Running in CPU mode
    Initializing from 	cv/checkpoint_10.t7
    reset_iterations: cv/checkpoint_10.t7 contains no iteration counter
    Epoch 1.00 / 50, i = 1 / 17800, loss = 3.474951
    Epoch 1.01 / 50, i = 2 / 17800, loss = 3.344084
    ...

The behaviour for checkpoints which do contain an iteration counter is unaffected.