### PR TITLE
Fix `util.DataLoader` to handle `extra=0` case

### DIFF
--- a/util/DataLoader.lua
+++ b/util/DataLoader.lua
@@ -26,6 +26,11 @@ function DataLoader:__init(kwargs)
     local num = v:nElement()
     local extra = num % (N * T)
 
+    -- Ensure that `vy` is non-empty
+    if extra == 0 then
+      extra = N * T
+    end
+
     -- Chop out the extra bits at the end to make it evenly divide
     local vx = v[{{1, num - extra}}]:view(N, -1, T):transpose(1, 2):clone()
     local vy = v[{{2, num - extra + 1}}]:view(N, -1, T):transpose(1, 2):clone()


### PR DESCRIPTION
`DataLoader` will currently throw an error if `extra = 0` (https://github.com/jcjohnson/torch-rnn/blob/master/util/DataLoader.lua#L27) because of an out of bound index into `vy` (https://github.com/jcjohnson/torch-rnn/blob/master/util/DataLoader.lua#L31).

```
Running with CUDA on GPU 0
/home/fl350/torch/install/bin/luajit: bad argument #2 to '?' (end index out of bound at /home/fl350/torch/pkg/torch/generic/Tensor.c:969)
stack traceback:
        [C]: at 0x7f89d1efde20
        [C]: in function '__index'
        ./util/DataLoader.lua:31: in function '__init'
        /home/fl350/torch/install/share/lua/5.1/torch/init.lua:91: in function </home/fl350/torch/install/share/lua/5.1/torch/init.lua:87>
        [C]: in function 'DataLoader'
        train.lua:76: in main chunk
        [C]: in function 'dofile'
        ...l350/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:145: in main chunk
        [C]: at 0x00405da0
```

This PR addresses this by ensuring `extra > 0`