### PR TITLE
Documentation:  Indicate missing defaults in flags.

### DIFF
--- a/doc/flags.md
+++ b/doc/flags.md
@@ -16,7 +16,7 @@ The training script `train.lua` accepts the following command-line flags:
 **Data options**:
 - `-input_h5`, `-input_json`: Paths to the HDF5 and JSON files output from the preprocessing script.
 - `-batch_size`: Number of sequences to use in a minibatch; default is 50.
-- `-seq_length`: Number of timesteps for which the recurrent network is unrolled for backpropagation through time.
+- `-seq_length`: Number of timesteps for which the recurrent network is unrolled for backpropagation through time; default is 50.
 
 **Model options**:
 - `-init_from`: Path to a checkpoint file from a previous run of `train.lua`. Use this to continue training from an existing checkpoint; if this flag is passed then the other flags in this section will be ignored and the architecture from the existing checkpoint will be used instead.
@@ -24,7 +24,7 @@ The training script `train.lua` accepts the following command-line flags:
 - `-model_type`: The type of recurrent network to use; either `lstm` (default) or `rnn`. `lstm` is slower but better.
 - `-wordvec_size`: Dimension of learned word vector embeddings; default is 64. You probably won't need to change this.
 - `-rnn_size`: The number of hidden units in the RNN; default is 128. Larger values (256 or 512) are commonly used to learn more powerful models and for bigger datasets, but this will significantly slow down computation.
-- `-dropout`: Amount of dropout regularization to apply after each RNN layer; must be in the range `0 <= dropout < 1`. Setting `dropout` to 0 disables dropout, and higher numbers give a stronger regularizing effect.
+- `-dropout`: Amount of dropout regularization to apply after each RNN layer; must be in the range `0 <= dropout < 1`. Setting `dropout` to 0 disables dropout, and higher numbers give a stronger regularizing effect; default is 0.
 - `-num_layers`: The number of layers present in the RNN; default is 2.
 
 **Optimization options**:


### PR DESCRIPTION
This is a very small pull request.  The `flags.md` file has been update in 2 places.  Specifically, the default values are now listed for the `-seq_length` and `-dropout` command line options.