### PR TITLE
Sampling with start_text with 2-bytes charaters

### DIFF
--- a/LanguageModel.lua
+++ b/LanguageModel.lua
@@ -123,12 +123,23 @@ end
 
 function LM:encode_string(s)
   local encoded = torch.LongTensor(#s)
-  for i = 1, #s do
+  local i = 1
+  local j = 1
+  while i <= #s do
     local token = s:sub(i, i)
     local idx = self.token_to_idx[token]
+    if idx == nil and i < #s then
+      token = s:sub(i, i + 1)
+      idx = self.token_to_idx[token]
+      i = i + 1
+    end
     assert(idx ~= nil, 'Got invalid idx')
-    encoded[i] = idx
+    encoded[j] = idx
+
+    i = i + 1
+    j = j + 1
   end
+  encoded:resize(j - 1)
   return encoded
 end
 


### PR DESCRIPTION
I trained the language model on some Romanian texts which contained some 2-bytes characters such as the Romanian ă, â, î, ș, ț and everything went good util I tried some sampling with a start_text that contained such characters. I am not a Lua programmer (I'm a C/C++ and barely Python programmer), but somehow I managed to fix that. It seems to work fine now but I'm not perfectly sure about that, so please someone take a brief look over my modifications, I really don't want to damage this awesome project.