### PR TITLE
Fill and write each array before creating the next one, to save memory.

### DIFF
--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -45,7 +45,13 @@ if __name__ == '__main__':
   # Choose the datatype based on the vocabulary size
   dtype = np.uint8
   if len(token_to_idx) > 255:
-    dtype = np.uint32
+      if len(token_to_idx) > 65535:
+          if len(token_to_idx) > 4294967295:
+              dtype = np.uint64
+          else:
+            dtype = np.uint32
+      else:
+        dtype = np.uint16
   if not args.quiet:
     print 'Using dtype ', dtype
 

--- a/scripts/preprocess.py
+++ b/scripts/preprocess.py
@@ -43,15 +43,15 @@ if __name__ == '__main__':
     print '  Test size: %d' % test_size
 
   # Choose the datatype based on the vocabulary size
-  dtype = np.uint8
-  if len(token_to_idx) > 255:
-      if len(token_to_idx) > 65535:
-          if len(token_to_idx) > 4294967295:
-              dtype = np.uint64
-          else:
-            dtype = np.uint32
-      else:
-        dtype = np.uint16
+  if len(token_to_idx) > 4294967295:
+      dtype = np.uint64
+  elif len(token_to_idx) > 65535:
+    dtype = np.uint32
+  elif len(token_to_idx) > 255:
+      dtype = np.uint16
+  else:
+      dtype = np.uint8
+
   if not args.quiet:
     print 'Using dtype ', dtype
 
@@ -60,25 +60,25 @@ if __name__ == '__main__':
   with codecs.open(args.input_txt, 'r', args.encoding) as f:
     with h5py.File(args.output_h5, 'w') as h:
       def fill_and_store(arr_size, set_name):
-          """Create a one-dimensional numpy array
-          of the given size, fill it,
-          and write the result to h under the given name.
+        """Create a one-dimensional numpy array
+        of the given size, fill it,
+        and write the result to h under the given name.
 
-          Leaves the source file advanced as far
-          as it had to go to fill the array.
+        Leaves the source file advanced as far
+        as it had to go to fill the array.
 
-          If the remaining part of the file is shorter
-          than arr_size, the remainder of the array is
-          filled with zeroes.
-          """
-          arr = np.zeros(arr_size, dtype=dtype)
-          for idx in xrange(arr_size):
-              char = f.read(1)
-              if not char:
-                  break
-              arr[idx] = token_to_idx[char]
+        If the remaining part of the file is shorter
+        than arr_size, the remainder of the array is
+        filled with zeroes.
+        """
+        arr = np.zeros(arr_size, dtype=dtype)
+        for idx in xrange(arr_size):
+          char = f.read(1)
+          if not char:
+            break
+          arr[idx] = token_to_idx[char]
 
-          h.create_dataset(set_name, data=arr)
+        h.create_dataset(set_name, data=arr)
 
       fill_and_store(train_size, 'train')
       fill_and_store(val_size, 'val')


### PR DESCRIPTION
The previous version said "we'll have to do something more clever for huge datasets."

I tried this with a huge dataset (the entire five-CD Okami soundtrack, WAV-formatted with headers stripped out, tracks separated by five seconds of silence, repeated three times and shuffled... about 10G, but then the preprocessor maps each byte to a unit32 so it gets magnified a bit).

I wouldn't call it "something clever," but it seems to work. All I did was re-organize things so that instead of making all the numpy arrays at once, filling them, and writing them all to h5 files, it makes one, fills it, writes it, garbage-collects it, then goes on to the next.