### PR TITLE
Add epoch and validation loss to checkpoint

### DIFF
--- a/train.lua
+++ b/train.lua
@@ -227,7 +227,7 @@ for i = start_i + 1, num_iterations do
       memory_usage = memory_usage,
       i = i
     }
-    local filename = string.format('%s_%d.json', opt.checkpoint_name, i)
+    local filename = string.format('%s_%d_epoch%.2f_%.4f.json', opt.checkpoint_name, i, epoch, val_loss)
     -- Make sure the output directory exists before we try to write it
     paths.mkdir(paths.dirname(filename))
     utils.write_json(filename, checkpoint)
@@ -237,7 +237,7 @@ for i = start_i + 1, num_iterations do
     model:clearState()
     model:float()
     checkpoint.model = model
-    local filename = string.format('%s_%d.t7', opt.checkpoint_name, i)
+    local filename = string.format('%s_%d_epoch%.2f_$.4f.t7', opt.checkpoint_name, i, epoch, val_loss)
     paths.mkdir(paths.dirname(filename))
     torch.save(filename, checkpoint)
     model:type(dtype)


### PR DESCRIPTION
Update the checkpoint filename to include the epoch value and validation loss value so we sample against a checkpoint with a lower (or not!) validation loss. From [Karpathy's](https://github.com/karpathy) [char-rnn](https://github.com/karpathy/char-rnn) implementation.