### PR TITLE
Updates for compatibility with changes in new HDF5 packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 .ipynb_checkpoints/
 .env/
+my_data.*

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .ipynb_checkpoints/
 .env/
 my_data.*
+cv/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # torch-rnn
+This repository is a fork of [torch-rnn](https://github.com/jcjohnson/torch-rnn) with modifications to improve compatibility with more recent versions of some dependences and an added example of a network trained to simulate the contents of RFC standards.
+
 torch-rnn provides high-performance, reusable RNN and LSTM modules for torch7, and uses these modules for character-level
 language modeling similar to [char-rnn](https://github.com/karpathy/char-rnn).
 
@@ -158,6 +160,14 @@ By default the sampling script will run in GPU mode using CUDA; to run in CPU-on
 to run in OpenCL mode add the flag `-gpu_backend opencl`.
 
 There are more flags you can use to configure sampling; [read about them here](doc/flags.md#sampling).
+
+# Example network - RFC simulation
+
+This repository contains an example of a trained LSTM network that simulates the contents of [rfc standards](https://en.wikipedia.org/wiki/Request_for_Comments) that are used to define Internet Protocols. The network has been trained with the text of all RFCs published to date. You can try generating your own RFC samples like this:
+
+```bash
+th sample.lua -checkpoint example-rfcs/rfcs.t7 -length 2000
+```
 
 # Benchmarks
 To benchmark `torch-rnn` against `char-rnn`, we use each to train LSTM language models for the tiny-shakespeare dataset

--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ the [Benchmark](#benchmarks) section below.
 
 # Installation
 
-## Docker Images
-Cristian Baldi has prepared Docker images for both CPU-only mode and GPU mode;
-you can [find them here](https://github.com/crisbal/docker-torch-rnn).
-
 ## System setup
 You'll need to install the header files for Python 2.7 and the HDF5 library. On Ubuntu you should be able to install
 like this:

--- a/README.md
+++ b/README.md
@@ -56,9 +56,22 @@ luarocks install optim
 luarocks install lua-cjson
 
 # We need to install torch-hdf5 from GitHub
-git clone https://github.com/deepmind/torch-hdf5
+git clone https://github.com/anibali/torch-hdf5.git
+# Note that if you use the original version of torch-hdf5 from deepmind
+# it is currently incompatible with the HDF5 V1.1.0 library versions
+# used by several recent OS versions including Ubuntu V17.04 and newer MacOS
 cd torch-hdf5
+git checkout hdf5-1.10 
 luarocks make hdf5-0-0.rockspec
+
+# There can be a problem finding the hdf5.h file from Lua. This may be a poor solution, but
+# it works for me.
+
+# Find the hdf5.h file
+find / -name hdf5.h 2>/dev/null
+# edit the file ~/torch/install/share/lua/5.1/hdf5/config.lua
+# and set "HDF5_INCLUDE_PATH to the directory that contains the hdf5.h file
+
 ```
 
 ### CUDA support (Optional)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Cython==0.23.4
 numpy==1.10.4
 argparse==1.2.1
-h5py==2.5.0
+h5py==2.7.1
 six==1.10.0


### PR DESCRIPTION
The current dependency file and instructions don't work on OS, like Ubuntu V17.4, that use a package with version 1.10 of HDF5. These updates address that.